### PR TITLE
Begin issue number 8

### DIFF
--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,0 +1,21 @@
+/**
+ * Compute score for a word length using the defined mapping:
+ * 4 → 1, 5 → 2, 6 → 3, 7 → 5, 8+ → 11. Lengths < 4 score 0.
+ */
+export function scoreWordLength(length: number): number {
+  if (!Number.isFinite(length)) return 0;
+  const n = Math.floor(length);
+  if (n < 4) return 0;
+  switch (n) {
+    case 4:
+      return 1;
+    case 5:
+      return 2;
+    case 6:
+      return 3;
+    case 7:
+      return 5;
+    default:
+      return 11; // 8+
+  }
+}

--- a/tests/scoring.test.ts
+++ b/tests/scoring.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { scoreWordLength } from "@/lib/scoring";
+
+/** Mapping: 4→1, 5→2, 6→3, 7→5, 8+→11 */
+describe("scoreWordLength", () => {
+  it("scores below 4 as 0", () => {
+    expect(scoreWordLength(0)).toBe(0);
+    expect(scoreWordLength(1)).toBe(0);
+    expect(scoreWordLength(2)).toBe(0);
+    expect(scoreWordLength(3)).toBe(0);
+  });
+
+  it("scores exact lengths per table", () => {
+    expect(scoreWordLength(4)).toBe(1);
+    expect(scoreWordLength(5)).toBe(2);
+    expect(scoreWordLength(6)).toBe(3);
+    expect(scoreWordLength(7)).toBe(5);
+    expect(scoreWordLength(8)).toBe(11);
+    expect(scoreWordLength(12)).toBe(11);
+  });
+
+  it("floors non-integer inputs", () => {
+    expect(scoreWordLength(3.9)).toBe(0);
+    expect(scoreWordLength(4.1)).toBe(1);
+    expect(scoreWordLength(7.99)).toBe(5);
+  });
+
+  it("handles non-finite numbers as 0", () => {
+    expect(scoreWordLength(Number.NaN)).toBe(0);
+    expect(scoreWordLength(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(scoreWordLength(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- This PR introduces a new utility function `scoreWordLength` and its corresponding unit tests.
- It addresses issue #8, providing a standardized way to calculate scores based on word length.

## Changes
- [x] Added `lib/scoring.ts` containing the `scoreWordLength` function.
- [x] Added `tests/scoring.test.ts` with comprehensive tests for the new utility.
- [ ] No breaking changes.

## Checklist
- [x] Linked issue and added context (Issue #8)
- [x] Added/updated tests
- [x] `npm run lint` passes (no warnings)
- [x] `npm run typecheck` passes
- [x] `npm test` passes

## Screenshots / Demos (if UI)
N/A

## Notes for Reviewers
This is a small, focused PR implementing a single utility function and its tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-a11c4aae-d577-4060-a457-72da0ffdd049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a11c4aae-d577-4060-a457-72da0ffdd049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

