### PR TITLE
Add validation API route and shared board helpers

### DIFF
--- a/app/api/board/route.ts
+++ b/app/api/board/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { generateBoardForDate } from "@/lib/board/generate";
 import type { Board } from "@/lib/board/types";
+import {
+  flattenBoard,
+  resolveBoardDate,
+  resolveDailySalt,
+} from "@/lib/board/api-helpers";
 
 export type BoardResponse = {
   status: "ok";
@@ -12,43 +17,12 @@ export type BoardResponse = {
   };
 };
 
-function normalizeDateInput(dateParam: string | null): string | null {
-  if (!dateParam) return null;
-  const s = dateParam.trim();
-  if (s.length === 0) return null;
-  // basic ISO date validation (YYYY-MM-DD)
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
-  return s;
-}
-
-function formatDateUTC(date: Date): string {
-  const y = date.getUTCFullYear();
-  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(date.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-function flattenBoard(board: Board): string {
-  let out = "";
-  for (let r = 0; r < board.length; r++) {
-    for (let c = 0; c < board[r].length; c++) {
-      out += board[r][c];
-    }
-  }
-  return out;
-}
-
 export async function GET(req?: Request) {
   const url = req ? new URL(req.url) : null;
   const dateParam = url ? url.searchParams.get("date") : null;
-  const normalized = normalizeDateInput(dateParam);
+  const date = resolveBoardDate(dateParam);
 
-  const date: string = normalized ?? formatDateUTC(new Date());
-
-  const envSaltRaw = typeof process?.env?.BOARD_DAILY_SALT === "string" ? process.env.BOARD_DAILY_SALT : null;
-  const envSalt = envSaltRaw ? envSaltRaw.trim() : null;
-  const hasDailySalt = Boolean(envSalt && envSalt.length > 0);
-  const salt = hasDailySalt ? (envSalt as string) : "dev-salt";
+  const { salt, hasDailySalt } = resolveDailySalt();
 
   const board = generateBoardForDate(date, salt);
 

--- a/app/api/validate/route.ts
+++ b/app/api/validate/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { generateBoardForDate } from "@/lib/board/generate";
+import { flattenBoard, resolveBoardDate, resolveDailySalt } from "@/lib/board/api-helpers";
+import type { Coord } from "@/lib/validation/adjacency";
+import { validateWord, type WordCheck } from "@/lib/validation/words";
+
+export type ValidateRequestBody = {
+  date?: string | null;
+  path?: unknown;
+};
+
+export type ValidateResponse = {
+  status: "ok";
+  date: string;
+  env: {
+    hasDailySalt: boolean;
+  };
+  letters: string;
+  result: WordCheck;
+};
+
+export type ValidateErrorResponse = {
+  status: "error";
+  error: "invalid-json" | "invalid-path";
+};
+
+function isCoordTuple(value: unknown): value is Coord {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === "number" &&
+    Number.isInteger(value[0]) &&
+    typeof value[1] === "number" &&
+    Number.isInteger(value[1])
+  );
+}
+
+function isCoordArray(value: unknown): value is Coord[] {
+  return Array.isArray(value) && value.every(isCoordTuple);
+}
+
+export async function POST(req: Request) {
+  let body: ValidateRequestBody;
+  try {
+    body = (await req.json()) as ValidateRequestBody;
+  } catch {
+    const errorBody: ValidateErrorResponse = { status: "error", error: "invalid-json" };
+    return NextResponse.json(errorBody, { status: 400 });
+  }
+
+  if (!isCoordArray(body.path)) {
+    const errorBody: ValidateErrorResponse = { status: "error", error: "invalid-path" };
+    return NextResponse.json(errorBody, { status: 400 });
+  }
+
+  const date = resolveBoardDate(typeof body.date === "string" ? body.date : null);
+  const { salt, hasDailySalt } = resolveDailySalt();
+  const board = generateBoardForDate(date, salt);
+  const result = validateWord(board, body.path);
+
+  const response: ValidateResponse = {
+    status: "ok",
+    date,
+    env: { hasDailySalt },
+    letters: flattenBoard(board),
+    result,
+  };
+
+  return NextResponse.json(response, { status: 200 });
+}

--- a/lib/board/api-helpers.ts
+++ b/lib/board/api-helpers.ts
@@ -1,0 +1,40 @@
+import type { Board } from "@/lib/board/types";
+
+export function normalizeDateInput(dateParam: string | null | undefined): string | null {
+  if (!dateParam) return null;
+  const trimmed = dateParam.trim();
+  if (trimmed.length === 0) return null;
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : null;
+}
+
+export function formatDateUTC(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function resolveBoardDate(dateParam: string | null | undefined): string {
+  const normalized = normalizeDateInput(dateParam);
+  return normalized ?? formatDateUTC(new Date());
+}
+
+export function flattenBoard(board: Board): string {
+  let out = "";
+  for (let r = 0; r < board.length; r++) {
+    for (let c = 0; c < board[r].length; c++) {
+      out += board[r][c];
+    }
+  }
+  return out;
+}
+
+export function resolveDailySalt(): { salt: string; hasDailySalt: boolean } {
+  const raw = typeof process?.env?.BOARD_DAILY_SALT === "string" ? process.env.BOARD_DAILY_SALT : null;
+  const trimmed = raw ? raw.trim() : "";
+  const hasDailySalt = trimmed.length > 0;
+  return {
+    salt: hasDailySalt ? trimmed : "dev-salt",
+    hasDailySalt,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --reporter=dot",
+    "test": "vitest run --reporter=verbose",
     "validate": "npm run lint && npm run typecheck && npm test",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/tests/validate.api.test.ts
+++ b/tests/validate.api.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { POST, type ValidateErrorResponse, type ValidateResponse } from "../app/api/validate/route";
+
+const originalEnv = process.env;
+
+const VALID_PATH: [number, number][] = [
+  [1, 1],
+  [2, 1],
+  [1, 2],
+  [0, 3],
+];
+
+const INVALID_PATH: [number, number][] = [
+  [0, 0],
+  [0, 2],
+  [0, 3],
+  [0, 4],
+];
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  vi.useRealTimers();
+});
+
+describe("POST /api/validate", () => {
+  it("validates a path and returns dictionary word when salt present", async () => {
+    process.env.BOARD_DAILY_SALT = "unit-test-salt";
+
+    const res = await POST(
+      new Request("http://localhost/api/validate", {
+        method: "POST",
+        body: JSON.stringify({ date: "2025-01-02", path: VALID_PATH }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as ValidateResponse;
+    expect(json.status).toBe("ok");
+    expect(json.date).toBe("2025-01-02");
+    expect(json.env.hasDailySalt).toBe(true);
+    expect(json.result.ok).toBe(true);
+    expect(json.result.word).toBe("AIDS");
+    expect(json.letters).toMatch(/^[A-Z]{25}$/);
+  });
+
+  it("returns invalid-path error for malformed coordinate arrays", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/validate", {
+        method: "POST",
+        body: JSON.stringify({ date: "2025-01-02", path: "oops" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as ValidateErrorResponse;
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-path");
+  });
+
+  it("defaults date when omitted and indicates hasDailySalt=false", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2025, 0, 5)));
+
+    const res = await POST(
+      new Request("http://localhost/api/validate", {
+        method: "POST",
+        body: JSON.stringify({ path: INVALID_PATH }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as ValidateResponse;
+    expect(json.status).toBe("ok");
+    expect(json.date).toBe("2025-01-05");
+    expect(json.env.hasDailySalt).toBe(false);
+    expect(json.result.ok).toBe(false);
+    expect(json.result.reason).toBe("invalid-path");
+  });
+
+  it("rejects invalid JSON payloads", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/validate", {
+        method: "POST",
+        body: "{", // malformed JSON
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as ValidateErrorResponse;
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-json");
+  });
+});


### PR DESCRIPTION
## Summary
- add shared helpers for normalizing board dates, flattening boards, and reading the daily salt
- implement `POST /api/validate` to score submitted paths against the deterministic board
- cover the new endpoint with Vitest integration tests and switch the test reporter to verbose to avoid terminal issues

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69067bd30c08833394663cc13e3386c0