### PR TITLE
Implement submission API for recording daily entries

### DIFF
--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db/client";
+import { submissions } from "@/db/schema";
+import { resolveBoardDate } from "@/lib/board/api-helpers";
+import { sql } from "drizzle-orm";
+
+type SubmitRequestBody = {
+  userId?: unknown;
+  date?: string | null;
+  words?: unknown;
+  score?: unknown;
+};
+
+export type SubmitSuccessResponse = {
+  status: "ok";
+  date: string;
+  submission: {
+    id: number;
+    userId: string;
+    words: string[];
+    score: number;
+    createdAt: string | null;
+  };
+};
+
+type SubmitError =
+  | "invalid-json"
+  | "invalid-user"
+  | "invalid-words"
+  | "invalid-score"
+  | "database-error";
+
+export type SubmitErrorResponse = {
+  status: "error";
+  error: SubmitError;
+};
+
+function normalizeUserId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeWords(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const normalized: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") return null;
+    const trimmed = item.trim();
+    if (trimmed.length === 0) return null;
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function normalizeScore(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const floored = Math.floor(value);
+  return floored >= 0 ? floored : null;
+}
+
+function errorResponse(error: SubmitError, status = 400) {
+  const body: SubmitErrorResponse = { status: "error", error };
+  return NextResponse.json(body, { status });
+}
+
+export async function POST(req: Request) {
+  let payload: SubmitRequestBody;
+  try {
+    payload = (await req.json()) as SubmitRequestBody;
+  } catch {
+    return errorResponse("invalid-json", 400);
+  }
+
+  const userId = normalizeUserId(payload.userId);
+  if (!userId) {
+    return errorResponse("invalid-user", 400);
+  }
+
+  const words = normalizeWords(payload.words);
+  if (!words) {
+    return errorResponse("invalid-words", 400);
+  }
+
+  const score = normalizeScore(payload.score);
+  if (score === null) {
+    return errorResponse("invalid-score", 400);
+  }
+
+  const date = resolveBoardDate(typeof payload.date === "string" ? payload.date : null);
+
+  try {
+    const result = await db
+      .insert(submissions)
+      .values({
+        userId,
+        date,
+        words: JSON.stringify(words),
+        score,
+      })
+      .onConflictDoUpdate({
+        target: [submissions.userId, submissions.date],
+        set: {
+          words: sql`excluded.words`,
+          score: sql`excluded.score`,
+        },
+      })
+      .returning();
+
+    const record = result[0];
+    if (!record) {
+      return errorResponse("database-error", 500);
+    }
+
+    const body: SubmitSuccessResponse = {
+      status: "ok",
+      date,
+      submission: {
+        id: record.id,
+        userId: record.userId,
+        words,
+        score: record.score,
+        createdAt: record.createdAt instanceof Date ? record.createdAt.toISOString() : null,
+      },
+    };
+
+    return NextResponse.json(body, { status: 200 });
+  } catch (error) {
+    console.error("Failed to record submission", error);
+    return errorResponse("database-error", 500);
+  }
+}

--- a/tests/submit.api.test.ts
+++ b/tests/submit.api.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubmitSuccessResponse } from "../app/api/submit/route";
+
+type StoredSubmission = {
+  id: number;
+  userId: string;
+  date: string;
+  words: string;
+  score: number;
+  createdAt: Date;
+};
+
+type StoreState = {
+  records: Map<string, StoredSubmission>;
+  nextId: number;
+};
+
+const storeState = vi.hoisted<StoreState>(() => ({
+  records: new Map<string, StoredSubmission>(),
+  nextId: 1,
+}));
+
+vi.mock("@/db/client", () => {
+  function makeReturning(values: { userId: string; date: string; words: string; score: number }) {
+    return async () => {
+      const key = `${values.userId}|${values.date}`;
+      const now = new Date();
+      const existing = storeState.records.get(key);
+      if (existing) {
+        existing.words = values.words;
+        existing.score = values.score;
+        existing.createdAt = now;
+        return [{ ...existing }];
+      }
+      const record: StoredSubmission = {
+        id: storeState.nextId++,
+        userId: values.userId,
+        date: values.date,
+        words: values.words,
+        score: values.score,
+        createdAt: now,
+      };
+      storeState.records.set(key, record);
+      return [{ ...record }];
+    };
+  }
+
+  return {
+    db: {
+      insert: () => ({
+        values(values: { userId: string; date: string; words: string; score: number }) {
+          return {
+            onConflictDoUpdate() {
+              return {
+                returning: makeReturning(values),
+              };
+            },
+          };
+        },
+      }),
+    },
+  };
+});
+
+function resetStore() {
+  storeState.records.clear();
+  storeState.nextId = 1;
+}
+
+beforeEach(() => {
+  resetStore();
+});
+
+describe("POST /api/submit", () => {
+  it("records a submission and returns metadata", async () => {
+    const { POST } = await import("../app/api/submit/route");
+    const request = new Request("http://localhost/api/submit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "user-123",
+        date: "2025-01-02",
+        words: ["aids", "gain"],
+        score: 5,
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as SubmitSuccessResponse;
+    expect(json.status).toBe("ok");
+    expect(json.date).toBe("2025-01-02");
+    expect(json.submission.userId).toBe("user-123");
+    expect(json.submission.words).toEqual(["aids", "gain"]);
+    expect(json.submission.score).toBe(5);
+    expect(typeof json.submission.id).toBe("number");
+    expect(json.submission.createdAt).toMatch(/T/);
+  });
+
+  it("upserts on the user/date combination", async () => {
+    const { POST } = await import("../app/api/submit/route");
+    const baseRequest = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    } satisfies RequestInit;
+
+    const first = await POST(
+      new Request("http://localhost/api/submit", {
+        ...baseRequest,
+        body: JSON.stringify({
+          userId: "user-456",
+          date: "2025-01-03",
+          words: ["WORD"],
+          score: 4,
+        }),
+      }),
+    );
+    const firstJson = (await first.json()) as SubmitSuccessResponse;
+    const firstId = firstJson.submission.id;
+
+    const second = await POST(
+      new Request("http://localhost/api/submit", {
+        ...baseRequest,
+        body: JSON.stringify({
+          userId: "user-456",
+          date: "2025-01-03",
+          words: ["NEW"],
+          score: 7,
+        }),
+      }),
+    );
+
+    const secondJson = (await second.json()) as SubmitSuccessResponse;
+    expect(secondJson.submission.id).toBe(firstId);
+    expect(secondJson.submission.words).toEqual(["NEW"]);
+    expect(secondJson.submission.score).toBe(7);
+  });
+
+  it("validates input payload", async () => {
+    const { POST } = await import("../app/api/submit/route");
+    const res = await POST(
+      new Request("http://localhost/api/submit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "", words: [], score: -1 }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.status).toBe("error");
+  });
+});


### PR DESCRIPTION
## Summary
- add POST /api/submit route that validates payloads and upserts daily submissions
- normalize incoming values and report structured success or error responses
- add unit tests covering happy path, idempotent upserts, and validation failures

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690680070b5c8333a293da8c202d5aac