### PR TITLE
Harden submit endpoint word validation

### DIFF
--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -42,14 +42,24 @@ function normalizeUserId(value: unknown): string | null {
 }
 
 function normalizeWords(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
+  if (!Array.isArray(value) || value.length === 0) return null;
+
   const normalized: string[] = [];
+  const seen = new Set<string>();
+
   for (const item of value) {
     if (typeof item !== "string") return null;
+
     const trimmed = item.trim();
     if (trimmed.length === 0) return null;
+
+    const duplicateKey = trimmed.toLowerCase();
+    if (seen.has(duplicateKey)) return null;
+    seen.add(duplicateKey);
+
     normalized.push(trimmed);
   }
+
   return normalized;
 }
 

--- a/tests/submit.api.test.ts
+++ b/tests/submit.api.test.ts
@@ -150,5 +150,42 @@ describe("POST /api/submit", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-user");
+  });
+
+  it("rejects empty word lists", async () => {
+    const { POST } = await import("../app/api/submit/route");
+    const res = await POST(
+      new Request("http://localhost/api/submit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "player", words: [], score: 0 }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-words");
+  });
+
+  it("rejects duplicate words regardless of casing", async () => {
+    const { POST } = await import("../app/api/submit/route");
+    const res = await POST(
+      new Request("http://localhost/api/submit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "player",
+          words: ["Word", " word ", "another"],
+          score: 10,
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-words");
   });
 });


### PR DESCRIPTION
## Summary
- ensure the submit endpoint rejects empty payloads and duplicate words when normalizing input
- extend submit API tests to verify the new validation behavior and asserted error codes

Fixes #17

## Testing
- npm run lint
- npm run typecheck
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911397c963c83339f39eac4f8cf5597)