### PR TITLE
Add submission API route and persistence helpers

### DIFF
--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { resolveBoardDate } from "@/lib/board/api-helpers";
+import { scoreWordLength } from "@/lib/scoring";
+import { upsertSubmission } from "@/lib/submissions/save";
+
+const MIN_WORD_LENGTH = 4;
+
+export type SubmitRequestBody = {
+  userId?: unknown;
+  date?: unknown;
+  words?: unknown;
+};
+
+export type SubmitResponse = {
+  status: "ok";
+  userId: string;
+  date: string;
+  words: string[];
+  wordCount: number;
+  score: number;
+};
+
+export type SubmitErrorResponse = {
+  status: "error";
+  error: "invalid-json" | "invalid-user" | "invalid-words";
+};
+
+function sanitizeUserId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeWords(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const unique: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of value) {
+    if (typeof entry !== "string") return null;
+    const trimmed = entry.trim();
+    if (trimmed.length < MIN_WORD_LENGTH) return null;
+    if (!/^[A-Za-z]+$/.test(trimmed)) return null;
+    const normalized = trimmed.toUpperCase();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      unique.push(normalized);
+    }
+  }
+
+  return unique;
+}
+
+function computeScore(words: string[]): number {
+  return words.reduce((total, word) => total + scoreWordLength(word.length), 0);
+}
+
+export async function POST(req: Request) {
+  let body: SubmitRequestBody;
+  try {
+    body = (await req.json()) as SubmitRequestBody;
+  } catch {
+    const errorBody: SubmitErrorResponse = { status: "error", error: "invalid-json" };
+    return NextResponse.json(errorBody, { status: 400 });
+  }
+
+  const userId = sanitizeUserId(body.userId);
+  if (!userId) {
+    const errorBody: SubmitErrorResponse = { status: "error", error: "invalid-user" };
+    return NextResponse.json(errorBody, { status: 400 });
+  }
+
+  const words = sanitizeWords(body.words);
+  if (!words || words.length === 0) {
+    const errorBody: SubmitErrorResponse = { status: "error", error: "invalid-words" };
+    return NextResponse.json(errorBody, { status: 400 });
+  }
+
+  const dateParam = typeof body.date === "string" ? body.date : null;
+  const date = resolveBoardDate(dateParam);
+  const score = computeScore(words);
+
+  await upsertSubmission({ userId, date, words, score });
+
+  const responseBody: SubmitResponse = {
+    status: "ok",
+    userId,
+    date,
+    words,
+    wordCount: words.length,
+    score,
+  };
+
+  return NextResponse.json(responseBody, { status: 200 });
+}

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,8 +1,12 @@
 import { drizzle } from "drizzle-orm/node-postgres";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
+import * as schema from "./schema";
 
 const connectionString =
   process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/postgres";
 
 export const pool = new Pool({ connectionString });
-export const db = drizzle(pool);
+export type Database = NodePgDatabase<typeof schema>;
+
+export const db: Database = drizzle(pool, { schema });

--- a/lib/submissions/save.ts
+++ b/lib/submissions/save.ts
@@ -1,0 +1,79 @@
+import { db, type Database } from "@/db/client";
+import { submissions } from "@/db/schema";
+
+export type SubmissionRecord = {
+  userId: string;
+  date: string;
+  words: string[];
+  score: number;
+};
+
+export type StoredSubmission = {
+  id: number;
+  userId: string;
+  date: string;
+  words: string[];
+  score: number;
+};
+
+export type UpsertOptions = {
+  db?: Pick<Database, "insert">;
+};
+
+function serializeWords(words: string[]): string {
+  return JSON.stringify(words);
+}
+
+function parseStoredWords(words: string): string[] {
+  try {
+    const parsed = JSON.parse(words);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function upsertSubmission(
+  record: SubmissionRecord,
+  options: UpsertOptions = {},
+): Promise<StoredSubmission> {
+  const database = (options.db as Database | undefined) ?? db;
+
+  const payload = {
+    userId: record.userId,
+    date: record.date,
+    words: serializeWords(record.words),
+    score: record.score,
+  };
+
+  const rows = await database
+    .insert(submissions)
+    .values(payload)
+    .onConflictDoUpdate({
+      target: [submissions.userId, submissions.date],
+      set: {
+        words: payload.words,
+        score: payload.score,
+      },
+    })
+    .returning({
+      id: submissions.id,
+      userId: submissions.userId,
+      date: submissions.date,
+      words: submissions.words,
+      score: submissions.score,
+    });
+
+  const row = rows[0];
+  if (!row) {
+    throw new Error("Failed to upsert submission");
+  }
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    date: row.date,
+    words: parseStoredWords(row.words),
+    score: row.score,
+  };
+}

--- a/tests/submissions.save.test.ts
+++ b/tests/submissions.save.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { upsertSubmission, type UpsertOptions } from "@/lib/submissions/save";
+
+type InsertPayload = {
+  userId: string;
+  date: string;
+  words: string;
+  score: number;
+};
+
+class FakeDatabase {
+  stored: (InsertPayload & { id: number }) | null = null;
+
+  insert() {
+    return {
+      values: (payload: InsertPayload) => {
+        if (!this.stored) {
+          this.stored = { ...payload, id: 1 };
+        } else {
+          this.stored = { ...this.stored, ...payload };
+        }
+
+        return {
+          onConflictDoUpdate: () => ({
+            returning: () =>
+              Promise.resolve([
+                {
+                  id: this.stored!.id,
+                  userId: this.stored!.userId,
+                  date: this.stored!.date,
+                  words: this.stored!.words,
+                  score: this.stored!.score,
+                },
+              ]),
+          }),
+        };
+      },
+    };
+  }
+}
+
+describe("upsertSubmission", () => {
+  it("serializes words and returns stored submission", async () => {
+    const fakeDb = new FakeDatabase();
+    const stored = await upsertSubmission(
+      { userId: "user-1", date: "2025-01-02", words: ["GAME"], score: 4 },
+      { db: fakeDb as UpsertOptions["db"] },
+    );
+
+    expect(stored.id).toBe(1);
+    expect(stored.words).toEqual(["GAME"]);
+    expect(fakeDb.stored?.words).toBe('["GAME"]');
+  });
+
+  it("updates existing submission on conflict", async () => {
+    const fakeDb = new FakeDatabase();
+
+    await upsertSubmission(
+      { userId: "user-1", date: "2025-01-02", words: ["GAME"], score: 4 },
+      { db: fakeDb as UpsertOptions["db"] },
+    );
+
+    const updated = await upsertSubmission(
+      { userId: "user-1", date: "2025-01-02", words: ["PUZZLE"], score: 10 },
+      { db: fakeDb as UpsertOptions["db"] },
+    );
+
+    expect(updated.score).toBe(10);
+    expect(updated.words).toEqual(["PUZZLE"]);
+    expect(fakeDb.stored?.words).toBe('["PUZZLE"]');
+  });
+});

--- a/tests/submit.api.test.ts
+++ b/tests/submit.api.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { POST, type SubmitResponse, type SubmitErrorResponse } from "@/app/api/submit/route";
+import { upsertSubmission } from "@/lib/submissions/save";
+
+vi.mock("@/lib/submissions/save", () => ({
+  upsertSubmission: vi.fn().mockResolvedValue({ id: 1 }),
+}));
+
+const mockedUpsert = upsertSubmission as unknown as Mock;
+
+describe("POST /api/submit", () => {
+  beforeEach(() => {
+    mockedUpsert.mockClear();
+  });
+
+  afterEach(() => {
+    mockedUpsert.mockClear();
+  });
+
+  it("persists submission and computes score", async () => {
+    const req = new Request("http://localhost/api/submit", {
+      method: "POST",
+      body: JSON.stringify({
+        userId: " user-42 ",
+        date: "2025-01-05",
+        words: ["game", " puzzle", "GAME"],
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SubmitResponse;
+    expect(json.status).toBe("ok");
+    expect(json.userId).toBe("user-42");
+    expect(json.date).toBe("2025-01-05");
+    expect(json.words).toEqual(["GAME", "PUZZLE"]);
+    expect(json.wordCount).toBe(2);
+    expect(json.score).toBe(4); // GAME (4 letters → 1) + PUZZLE (6 letters → 3)
+
+    expect(mockedUpsert).toHaveBeenCalledTimes(1);
+    expect(mockedUpsert).toHaveBeenCalledWith({
+      userId: "user-42",
+      date: "2025-01-05",
+      words: ["GAME", "PUZZLE"],
+      score: 4,
+    });
+  });
+
+  it("defaults date and rejects invalid JSON", async () => {
+    const req = new Request("http://localhost/api/submit", {
+      method: "POST",
+      body: "{ this is not json",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as SubmitErrorResponse;
+    expect(json.error).toBe("invalid-json");
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+
+  it("validates user id", async () => {
+    const req = new Request("http://localhost/api/submit", {
+      method: "POST",
+      body: JSON.stringify({ words: ["game"] }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as SubmitErrorResponse;
+    expect(json.error).toBe("invalid-user");
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+
+  it("validates words payload", async () => {
+    const req = new Request("http://localhost/api/submit", {
+      method: "POST",
+      body: JSON.stringify({ userId: "user-1", words: ["bad", "ok"] }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as SubmitErrorResponse;
+    expect(json.error).toBe("invalid-words");
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a POST /api/submit route that validates payloads, normalizes words, and computes scores before responding
- provide a reusable persistence helper that upserts submissions through the Drizzle client
- cover the new API and persistence logic with focused unit tests

Fixes #18

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6907922928288333a7c6ff0f32f65966)