### PR TITLE
Implement leaderboard API for #18

### DIFF
--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db/client";
+import { submissions } from "@/db/schema";
+import { resolveBoardDate } from "@/lib/board/api-helpers";
+import { asc, desc, eq, sql } from "drizzle-orm";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 50;
+
+function resolveLimit(raw: string | null | undefined): number | "invalid" {
+  if (raw == null) {
+    return DEFAULT_LIMIT;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return DEFAULT_LIMIT;
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return "invalid";
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (parsed < 1 || parsed > MAX_LIMIT) {
+    return "invalid";
+  }
+
+  return parsed;
+}
+
+function parseWordsField(value: unknown): string[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const words: string[] = [];
+    for (const item of parsed) {
+      if (typeof item === "string") {
+        const trimmed = item.trim();
+        if (trimmed.length > 0) {
+          words.push(trimmed);
+        }
+      }
+    }
+    return words;
+  } catch {
+    return [];
+  }
+}
+
+function formatSubmittedAt(value: unknown): string | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return null;
+}
+
+function normalizeUserId(value: unknown): string {
+  if (typeof value !== "string") {
+    return "unknown";
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : "unknown";
+}
+
+function normalizeScore(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+
+  const coerced = Number(value);
+  if (!Number.isFinite(coerced)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(coerced));
+}
+
+type LeaderboardError = "invalid-limit" | "database-error";
+
+export type LeaderboardErrorResponse = {
+  status: "error";
+  error: LeaderboardError;
+};
+
+export type LeaderboardEntry = {
+  rank: number;
+  userId: string;
+  score: number;
+  words: string[];
+  submittedAt: string | null;
+};
+
+export type LeaderboardResponse = {
+  status: "ok";
+  date: string;
+  limit: number;
+  totalPlayers: number;
+  entries: LeaderboardEntry[];
+};
+
+function errorResponse(error: LeaderboardError, status: number) {
+  const body: LeaderboardErrorResponse = { status: "error", error };
+  return NextResponse.json(body, { status });
+}
+
+export async function GET(req?: Request) {
+  const url = req ? new URL(req.url) : null;
+  const dateParam = url ? url.searchParams.get("date") : null;
+  const limitParam = url ? url.searchParams.get("limit") : null;
+
+  const date = resolveBoardDate(dateParam);
+  const limit = resolveLimit(limitParam);
+
+  if (limit === "invalid") {
+    return errorResponse("invalid-limit", 400);
+  }
+
+  try {
+    const rows = await db
+      .select({
+        id: submissions.id,
+        userId: submissions.userId,
+        score: submissions.score,
+        words: submissions.words,
+        createdAt: submissions.createdAt,
+      })
+      .from(submissions)
+      .where(eq(submissions.date, date))
+      .orderBy(desc(submissions.score), asc(submissions.createdAt), asc(submissions.id))
+      .limit(limit);
+
+    const totals = await db
+      .select({ value: sql<number>`cast(count(*) as integer)` })
+      .from(submissions)
+      .where(eq(submissions.date, date));
+
+    const totalPlayers = totals[0]?.value ?? 0;
+
+    const entries: LeaderboardEntry[] = rows.map((row, index) => ({
+      rank: index + 1,
+      userId: normalizeUserId(row.userId),
+      score: normalizeScore(row.score),
+      words: parseWordsField(row.words),
+      submittedAt: formatSubmittedAt(row.createdAt),
+    }));
+
+    const body: LeaderboardResponse = {
+      status: "ok",
+      date,
+      limit,
+      totalPlayers,
+      entries,
+    };
+
+    return NextResponse.json(body, { status: 200 });
+  } catch (error) {
+    console.error("Failed to fetch leaderboard", error);
+    return errorResponse("database-error", 500);
+  }
+}

--- a/tests/leaderboard.api.test.ts
+++ b/tests/leaderboard.api.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  LeaderboardErrorResponse,
+  LeaderboardResponse,
+} from "../app/api/leaderboard/route";
+
+type StoredRow = {
+  id: number;
+  userId: string;
+  score: number;
+  words: string;
+  createdAt: Date | string | null;
+};
+
+type StoreState = {
+  rows: StoredRow[];
+  total: number;
+  lastLimit: number | null;
+  throwOnQuery: boolean;
+};
+
+const store = vi.hoisted<StoreState>(() => ({
+  rows: [],
+  total: 0,
+  lastLimit: null,
+  throwOnQuery: false,
+}));
+
+vi.mock("@/db/client", () => {
+  return {
+    db: {
+      select(selector: unknown) {
+        if (store.throwOnQuery) {
+          throw new Error("query failed");
+        }
+
+        const isCountSelection =
+          typeof selector === "object" && selector !== null && "value" in (selector as Record<string, unknown>);
+
+        if (isCountSelection) {
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([{ value: store.total }]);
+                },
+              };
+            },
+          };
+        }
+
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  orderBy() {
+                    return {
+                      limit(limitValue: number) {
+                        store.lastLimit = limitValue;
+                        return Promise.resolve(store.rows.slice(0, limitValue));
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  store.rows = [];
+  store.total = 0;
+  store.lastLimit = null;
+  store.throwOnQuery = false;
+  vi.useRealTimers();
+});
+
+describe("GET /api/leaderboard", () => {
+  it("returns leaderboard entries for the requested date", async () => {
+    store.rows = [
+      {
+        id: 2,
+        userId: "user-b",
+        score: 15,
+        words: "[\"alpha\"]",
+        createdAt: new Date("2025-01-01T00:01:00Z"),
+      },
+      {
+        id: 3,
+        userId: "user-c",
+        score: 12,
+        words: "not-json",
+        createdAt: new Date("2025-01-01T00:02:00Z"),
+      },
+    ];
+    store.total = 3;
+
+    const { GET } = await import("../app/api/leaderboard/route");
+    const request = new Request("http://localhost/api/leaderboard?date=2025-01-01&limit=2");
+
+    const res = await GET(request);
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as LeaderboardResponse;
+    expect(json.status).toBe("ok");
+    expect(json.date).toBe("2025-01-01");
+    expect(json.limit).toBe(2);
+    expect(json.totalPlayers).toBe(3);
+    expect(json.entries).toHaveLength(2);
+
+    expect(json.entries[0]).toMatchObject({
+      rank: 1,
+      userId: "user-b",
+      score: 15,
+      words: ["alpha"],
+    });
+    expect(json.entries[0].submittedAt).toBe("2025-01-01T00:01:00.000Z");
+
+    expect(json.entries[1]).toMatchObject({
+      rank: 2,
+      userId: "user-c",
+      score: 12,
+      words: [],
+    });
+    expect(json.entries[1].submittedAt).toBe("2025-01-01T00:02:00.000Z");
+
+    expect(store.lastLimit).toBe(2);
+  });
+
+  it("defaults the date and limit when omitted", async () => {
+    store.rows = [
+      {
+        id: 1,
+        userId: "user-a",
+        score: 7,
+        words: "[\"word\"]",
+        createdAt: new Date("2025-02-02T12:00:00Z"),
+      },
+    ];
+    store.total = 1;
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-02-02T08:00:00Z"));
+
+    const { GET } = await import("../app/api/leaderboard/route");
+    const request = new Request("http://localhost/api/leaderboard");
+
+    const res = await GET(request);
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as LeaderboardResponse;
+    expect(json.date).toBe("2025-02-02");
+    expect(json.limit).toBe(25);
+    expect(json.entries).toHaveLength(1);
+    expect(store.lastLimit).toBe(25);
+  });
+
+  it("rejects invalid limit values", async () => {
+    const { GET } = await import("../app/api/leaderboard/route");
+    const request = new Request("http://localhost/api/leaderboard?limit=abc");
+
+    const res = await GET(request);
+    expect(res.status).toBe(400);
+
+    const json = (await res.json()) as LeaderboardErrorResponse;
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("invalid-limit");
+  });
+
+  it("handles database failures gracefully", async () => {
+    store.throwOnQuery = true;
+
+    const { GET } = await import("../app/api/leaderboard/route");
+    const request = new Request("http://localhost/api/leaderboard?date=2025-03-01");
+
+    const res = await GET(request);
+    expect(res.status).toBe(500);
+
+    const json = (await res.json()) as LeaderboardErrorResponse;
+    expect(json.status).toBe("error");
+    expect(json.error).toBe("database-error");
+  });
+});


### PR DESCRIPTION
## Summary
- add a GET /api/leaderboard endpoint that normalizes input, fetches submissions, and returns ranked entries
- harden leaderboard response parsing for stored JSON payloads and timestamps
- add API coverage for success, defaults, invalid limit handling, and database failures

## Testing
- npm run lint
- npm run typecheck
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912299346048333af4b7f92c3e31da4)