### PR TITLE
Enable touch dragging across word grid tiles

### DIFF
--- a/components/play/word-grid.tsx
+++ b/components/play/word-grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { Board } from "@/lib/board/types";
@@ -46,6 +47,20 @@ export function WordGrid({ board }: WordGridProps) {
     () => words.reduce((sum, entry) => sum + entry.score, 0),
     [words],
   );
+
+  useEffect(() => {
+    function stopDragging() {
+      setIsDragging(false);
+    }
+
+    window.addEventListener("pointerup", stopDragging);
+    window.addEventListener("pointercancel", stopDragging);
+
+    return () => {
+      window.removeEventListener("pointerup", stopDragging);
+      window.removeEventListener("pointercancel", stopDragging);
+    };
+  }, []);
 
   function resetPath(nextStatus?: Status) {
     setPath([]);
@@ -194,7 +209,14 @@ export function WordGrid({ board }: WordGridProps) {
                   aria-label={`Row ${rowIndex + 1}, Column ${colIndex + 1}: ${letter}${
                     isSelected ? " (selected)" : ""
                   }`}
-                  onPointerDown={() => {
+                  onPointerDown={(event: ReactPointerEvent<HTMLButtonElement>) => {
+                    if (event.pointerType === "touch") {
+                      const target = event.currentTarget;
+                      if (target.hasPointerCapture?.(event.pointerId)) {
+                        target.releasePointerCapture(event.pointerId);
+                      }
+                    }
+
                     setIsDragging(true);
                     handleSelect(rowIndex, colIndex);
                   }}


### PR DESCRIPTION
## Summary
- release implicit touch pointer capture on tile presses so drag selection can move between tiles
- reset drag state on pointer end events to keep selection interactions consistent

## Testing
- npm test -- tests/word-grid.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692265b67b5c8333b5d9fc8ef79bb93f)