### PR TITLE
Use physical dice for board generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A daily, deterministic, 5×5 word-finding game that blends the path-finding rule
 - Seeded by the calendar date plus a server-side salt to prevent spoofing
 - Example approach:
   - `seed = SHA256(YYYY-MM-DD + BOARD_DAILY_SALT)`
-  - Use a seeded PRNG to draw letters by frequency distribution
+- Use a seeded PRNG to shuffle a fixed set of physical dice and roll one face per die
   - Persist only the seed and/or board for auditing; derive board on-demand
 
 ### Data Model (Supabase Tables)

--- a/lib/board/generate.ts
+++ b/lib/board/generate.ts
@@ -1,59 +1,33 @@
 import { createPrng } from "@/lib/board/prng";
 import type { Board } from "@/lib/board/types";
 
-// Letter frequency weights (approximate English letter frequencies)
-// Values are relative; only ratios matter.
-const LETTER_WEIGHTS: Record<string, number> = {
-  A: 8167,
-  B: 1492,
-  C: 2782,
-  D: 4253,
-  E: 12702,
-  F: 2228,
-  G: 2015,
-  H: 6094,
-  I: 6966,
-  J: 153,
-  K: 772,
-  L: 4025,
-  M: 2406,
-  N: 6749,
-  O: 7507,
-  P: 1929,
-  Q: 95,
-  R: 5987,
-  S: 6327,
-  T: 9056,
-  U: 2758,
-  V: 978,
-  W: 2360,
-  X: 150,
-  Y: 1974,
-  Z: 74,
-};
-
-const LETTERS = Object.keys(LETTER_WEIGHTS);
-const CUMULATIVE: { letter: string; cum: number }[] = (() => {
-  let sum = 0;
-  return LETTERS.map((letter) => {
-    sum += LETTER_WEIGHTS[letter];
-    return { letter, cum: sum };
-  });
-})();
-const TOTAL_WEIGHT = CUMULATIVE[CUMULATIVE.length - 1].cum;
-
-function pickLetter(prng: ReturnType<typeof createPrng>): string {
-  const r = Math.floor(prng.next() * TOTAL_WEIGHT);
-  // binary search cumulative distribution
-  let lo = 0;
-  let hi = CUMULATIVE.length - 1;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (r < CUMULATIVE[mid].cum) hi = mid;
-    else lo = mid + 1;
-  }
-  return CUMULATIVE[lo].letter;
-}
+const PHYSICAL_DICE: readonly string[] = [
+  "FAYIRS",
+  "EEEEAM",
+  "TOOOTU",
+  "HORDNL",
+  "YRRRIP",
+  "TETTMO",
+  "DNAENN",
+  "HLRNDO",
+  "GAEMEU",
+  "WONOTU",
+  "VGRROW",
+  "PLETIC",
+  "ASRAFA",
+  "DNODHT",
+  "RFIASA",
+  "DROLHH",
+  "TESCCN",
+  "JKBXZQ",
+  "NAGMNE",
+  "SESUSN",
+  "PFSYRI",
+  "ITECIL",
+  "TETIII",
+  "EEEEAA",
+  "PIESTC",
+];
 
 function formatDate(date: string | Date): string {
   if (typeof date === "string") return date;
@@ -63,10 +37,25 @@ function formatDate(date: string | Date): string {
   return `${y}-${m}-${d}`;
 }
 
+function shuffleDice(prng: ReturnType<typeof createPrng>): string[] {
+  const dice = [...PHYSICAL_DICE];
+  for (let i = dice.length - 1; i > 0; i--) {
+    const j = prng.nextInt(i + 1);
+    [dice[i], dice[j]] = [dice[j], dice[i]];
+  }
+  return dice;
+}
+
+function rollDie(die: string, prng: ReturnType<typeof createPrng>): string {
+  const faceIndex = prng.nextInt(die.length);
+  return die[faceIndex];
+}
+
 export function generateBoardForDate(date: string | Date, salt: string): Board {
   const dateStr = formatDate(date);
   const prng = createPrng(`${dateStr}|${salt}`);
-  const cells: string[] = Array.from({ length: 25 }, () => pickLetter(prng));
+  const dice = shuffleDice(prng);
+  const cells: string[] = dice.map((die) => rollDie(die, prng));
   const board: Board = [
     [cells[0], cells[1], cells[2], cells[3], cells[4]],
     [cells[5], cells[6], cells[7], cells[8], cells[9]],


### PR DESCRIPTION
## Summary
- replace frequency-based letter selection with a physical dice set for board generation
- shuffle dice deterministically per date and roll a face from each die
- document the dice-based generation approach in the README

## Testing
- Not run (vitest `board.test.ts` hangs locally)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4d39793883338f8868a8b012276e)