### PR TITLE
Add word length distribution indicator to shared board

### DIFF
--- a/app/shared/[id]/page.tsx
+++ b/app/shared/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { urlIdToBoard } from "@/lib/board/api-helpers";
+import { findAllBoardWords, computeWordLengthCounts } from "@/lib/board/solver";
 import { SharedWordGrid } from "@/components/play/shared-word-grid";
 
 export const dynamic = "force-dynamic";
@@ -29,5 +30,8 @@ export default async function SharedBoardPage({ params }: SharedBoardPageProps) 
     notFound();
   }
 
-  return <SharedWordGrid board={board} />;
+  const allWords = findAllBoardWords(board);
+  const wordLengthCounts = computeWordLengthCounts(allWords);
+
+  return <SharedWordGrid board={board} wordLengthCounts={wordLengthCounts} />;
 }

--- a/components/play/shared-word-grid.tsx
+++ b/components/play/shared-word-grid.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 
 import type { Board } from "@/lib/board/types";
+import type { WordLengthCounts } from "@/lib/board/solver";
 import {
   findPathForWord,
   validateWord,
@@ -14,15 +15,17 @@ import { MIN_PATH_LENGTH } from "@/lib/validation/paths";
 import { flattenBoard } from "@/lib/board/api-helpers";
 
 import { BoardComponent, InteractionType, FeedbackState, FeedbackType } from "./minimal/Board";
+import { WordLengthDistribution } from "./minimal/WordLengthDistribution";
 import { WordList } from "./minimal/WordList";
 
 export type SharedWordGridProps = {
   board: Board;
+  wordLengthCounts: WordLengthCounts;
 };
 
 type AddedWord = { word: string; score: number };
 
-export function SharedWordGrid({ board }: SharedWordGridProps) {
+export function SharedWordGrid({ board, wordLengthCounts }: SharedWordGridProps) {
   // Generate a unique key for this board
   const boardKey = useMemo(() => `shared-words-${flattenBoard(board)}`, [board]);
 
@@ -40,6 +43,17 @@ export function SharedWordGrid({ board }: SharedWordGridProps) {
   // Sort words alphabetically
   const sortedWords = useMemo(() => {
     return [...words].sort((a, b) => a.word.localeCompare(b.word));
+  }, [words]);
+
+  // Compute found word length counts for the distribution indicator
+  const foundLengthCounts = useMemo(() => {
+    const counts: WordLengthCounts = { "4": 0, "5": 0, "6": 0, "7": 0, "8+": 0 };
+    words.forEach(w => {
+      const len = w.word.length;
+      if (len >= 8) counts["8+"]++;
+      else if (len >= 4) counts[String(len)]++;
+    });
+    return counts;
   }, [words]);
 
   // Calculate highlighted cells based on input or drag
@@ -316,6 +330,9 @@ export function SharedWordGrid({ board }: SharedWordGridProps) {
             Minimum {MIN_PATH_LENGTH} letters. Drag on the board or type to find words.
           </p>
         </div>
+
+        {/* Word Length Distribution */}
+        <WordLengthDistribution totalCounts={wordLengthCounts} foundCounts={foundLengthCounts} />
 
         {/* Words List */}
         <div className="bg-slate-800/50 border border-white/10 rounded-lg p-4">


### PR DESCRIPTION
## Summary

This PR adds a word length distribution component to the shared word grid page, displaying both the total possible words by length and the user's found words by length. This gives players visual feedback on their progress across different word lengths.

## Changes

- Added `WordLengthDistribution` component import and rendering to `SharedWordGrid`
- Added `wordLengthCounts` prop to `SharedWordGridProps` to receive total word counts by length
- Computed `foundLengthCounts` from user-found words, categorizing by length (4, 5, 6, 7, 8+)
- Updated `SharedBoardPage` to compute word length counts server-side using `findAllBoardWords` and `computeWordLengthCounts`
- Passed computed counts to `SharedWordGrid` component

## Checklist

- [x] Feature adds word length distribution visualization
- [x] No breaking changes
- [x] Server-side computation of word counts for performance

## Notes for Reviewers

This is a straightforward feature addition that:
1. Computes word length statistics server-side (efficient, no client-side overhead)
2. Tracks found words client-side in the existing `words` state
3. Renders a new distribution component with both total and found counts

The implementation reuses existing solver utilities and follows the established component patterns in the codebase.

https://claude.ai/code/session_01FCoHEcpFh759dHCb7sAQYC