### PR TITLE
Filter word list by tapping ring progress indicators

### DIFF
--- a/components/play/minimal/ActionPanel.tsx
+++ b/components/play/minimal/ActionPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useState } from "react";
 import { Timer } from "./Timer";
 import { FoundWords } from "./FoundWords";
 import { WordLengthDistribution } from "./WordLengthDistribution";
@@ -51,6 +52,20 @@ export function ActionPanel({
   onRevealWords
 }: ActionPanelProps) {
   const inputDisabled = isPaused || !gameStarted || !!revealedWords;
+
+  const [selectedLengthBuckets, setSelectedLengthBuckets] = useState<Set<string>>(new Set());
+
+  const handleToggleBucket = useCallback((bucket: string) => {
+    setSelectedLengthBuckets(prev => {
+      const next = new Set(prev);
+      if (next.has(bucket)) {
+        next.delete(bucket);
+      } else {
+        next.add(bucket);
+      }
+      return next;
+    });
+  }, []);
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6 md:gap-8 md:p-0">
@@ -133,13 +148,19 @@ export function ActionPanel({
         </div>
       </div>
 
-      <WordLengthDistribution totalCounts={wordLengthCounts} foundCounts={foundLengthCounts} />
+      <WordLengthDistribution
+        totalCounts={wordLengthCounts}
+        foundCounts={foundLengthCounts}
+        selectedBuckets={selectedLengthBuckets}
+        onToggleBucket={handleToggleBucket}
+      />
 
       <FoundWords
         wordsWithinTime={wordsWithinTime}
         wordsAfterTime={wordsAfterTime}
         revealedWords={revealedWords}
         onRevealWords={onRevealWords}
+        selectedLengthBuckets={selectedLengthBuckets}
       />
 
       {userEmail && (

--- a/components/play/minimal/FoundWords.tsx
+++ b/components/play/minimal/FoundWords.tsx
@@ -4,15 +4,33 @@ import { useMemo, useRef } from "react";
 import { WordList } from "./WordList";
 import { scoreWordLength } from "@/lib/scoring";
 
+function wordLengthBucket(word: string): string {
+  const len = word.length;
+  if (len <= 7) return String(len);
+  return "8+";
+}
+
 interface FoundWordsProps {
   wordsWithinTime: { word: string; score: number }[];
   wordsAfterTime: { word: string; score: number }[];
   revealedWords?: string[] | null;
   onRevealWords?: () => void;
+  selectedLengthBuckets?: Set<string>;
 }
 
-export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onRevealWords }: FoundWordsProps) {
+export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onRevealWords, selectedLengthBuckets }: FoundWordsProps) {
   const listRef = useRef<HTMLDivElement>(null);
+
+  const hasFilter = selectedLengthBuckets && selectedLengthBuckets.size > 0;
+
+  const filteredWithinTime = useMemo(
+    () => hasFilter ? wordsWithinTime.filter(w => selectedLengthBuckets.has(wordLengthBucket(w.word))) : wordsWithinTime,
+    [wordsWithinTime, hasFilter, selectedLengthBuckets]
+  );
+  const filteredAfterTime = useMemo(
+    () => hasFilter ? wordsAfterTime.filter(w => selectedLengthBuckets.has(wordLengthBucket(w.word))) : wordsAfterTime,
+    [wordsAfterTime, hasFilter, selectedLengthBuckets]
+  );
 
   // Build the combined word list when revealed
   const allWordsDisplay = useMemo(() => {
@@ -31,6 +49,12 @@ export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onR
       .sort((a, b) => a.word.localeCompare(b.word));
   }, [revealedWords, wordsWithinTime, wordsAfterTime]);
 
+  const filteredAllWordsDisplay = useMemo(() => {
+    if (!allWordsDisplay) return null;
+    if (!hasFilter) return allWordsDisplay;
+    return allWordsDisplay.filter(w => selectedLengthBuckets!.has(wordLengthBucket(w.word)));
+  }, [allWordsDisplay, hasFilter, selectedLengthBuckets]);
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
@@ -41,9 +65,9 @@ export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onR
           ref={listRef}
           className="flex max-h-[300px] flex-col overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700"
         >
-          {revealedWords && allWordsDisplay ? (
+          {revealedWords && filteredAllWordsDisplay ? (
             <>
-              {allWordsDisplay.map((w, i) => (
+              {filteredAllWordsDisplay.map((w, i) => (
                 <div
                   key={`revealed-${i}`}
                   className={`flex justify-between py-1 text-sm ${
@@ -57,22 +81,24 @@ export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onR
                 </div>
               ))}
               <div className="mt-2 text-xs text-slate-500">
-                {allWordsDisplay.filter(w => w.found).length} / {allWordsDisplay.length} words found
+                {filteredAllWordsDisplay.filter(w => w.found).length} / {filteredAllWordsDisplay.length} words found
               </div>
             </>
-          ) : wordsWithinTime.length === 0 && wordsAfterTime.length === 0 ? (
-            <p className="text-sm italic text-slate-500">No words found yet</p>
+          ) : filteredWithinTime.length === 0 && filteredAfterTime.length === 0 ? (
+            <p className="text-sm italic text-slate-500">
+              {hasFilter ? "No words of this length" : "No words found yet"}
+            </p>
           ) : (
             <>
-              <WordList words={wordsWithinTime} emptyMessage="" />
+              <WordList words={filteredWithinTime} emptyMessage="" />
 
-              {wordsAfterTime.length > 0 && (
+              {filteredAfterTime.length > 0 && (
                 <>
                   <div className="my-2 border-b border-white/10" />
                   <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
                     Overtime
                   </div>
-                  {wordsAfterTime.map((w, i) => (
+                  {filteredAfterTime.map((w, i) => (
                     <div key={`after-${i}`} className="flex justify-between py-1 text-sm text-slate-500">
                       <span>{w.word}</span>
                       <span>({w.score} pts)</span>

--- a/components/play/minimal/WordLengthDistribution.tsx
+++ b/components/play/minimal/WordLengthDistribution.tsx
@@ -22,16 +22,22 @@ const BUCKET_COLORS: Record<string, string> = {
 interface WordLengthDistributionProps {
   totalCounts: WordLengthCounts;
   foundCounts: WordLengthCounts;
+  selectedBuckets?: Set<string>;
+  onToggleBucket?: (bucket: string) => void;
 }
 
 function RingProgress({
   bucket,
   total,
   found,
+  isSelected,
+  onToggle,
 }: {
   bucket: string;
   total: number;
   found: number;
+  isSelected?: boolean;
+  onToggle?: () => void;
 }) {
   const remaining = Math.max(0, total - found);
   const progress = total > 0 ? found / total : 0;
@@ -40,13 +46,31 @@ function RingProgress({
   const isComplete = total > 0 && remaining === 0;
 
   return (
-    <div className="flex flex-col items-center gap-1">
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`flex flex-col items-center gap-1 transition-all duration-200 ${
+        onToggle ? "cursor-pointer" : ""
+      } ${isSelected ? "scale-110" : "hover:scale-105"}`}
+    >
       <div className="relative" style={{ width: RING_SIZE, height: RING_SIZE }}>
         <svg
           width={RING_SIZE}
           height={RING_SIZE}
           viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
         >
+          {/* Selected highlight ring */}
+          {isSelected && (
+            <circle
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              stroke={color}
+              strokeWidth={STROKE_WIDTH + 2}
+              opacity={0.25}
+            />
+          )}
           {/* Background track */}
           <circle
             cx={RING_SIZE / 2}
@@ -86,14 +110,16 @@ function RingProgress({
           </span>
         </div>
       </div>
-      <span className="text-[11px] font-medium text-slate-500">{bucket}</span>
-    </div>
+      <span className={`text-[11px] font-medium ${isSelected ? "text-slate-100" : "text-slate-500"}`}>{bucket}</span>
+    </button>
   );
 }
 
 export function WordLengthDistribution({
   totalCounts,
   foundCounts,
+  selectedBuckets,
+  onToggleBucket,
 }: WordLengthDistributionProps) {
   return (
     <div className="flex w-full items-center justify-center gap-3 sm:gap-4">
@@ -107,6 +133,8 @@ export function WordLengthDistribution({
             bucket={bucket}
             total={total}
             found={found}
+            isSelected={selectedBuckets?.has(bucket)}
+            onToggle={onToggleBucket ? () => onToggleBucket(bucket) : undefined}
           />
         );
       })}


### PR DESCRIPTION
## Summary
- Tapping a word-length ring circle toggles filtering the word list to only show words of that length
- Multiple lengths can be selected simultaneously (e.g. tap 4 and 5 to see both)
- Tapping a selected ring deselects it; when no filters are active, all words are shown
- Selected rings get a highlight glow, scale up, and show a brighter label for visual feedback
- Filtering works on both the found words list and the revealed "All Words" list

## Test plan
- [ ] Tap a ring (e.g. "4") — word list should filter to only 4-letter words
- [ ] Tap another ring (e.g. "5") — word list should show both 4 and 5-letter words
- [ ] Tap "5" again — should deselect, showing only 4-letter words
- [ ] Tap "4" to deselect — all words should show again (no filter)
- [ ] Verify filtering works after revealing all words
- [ ] Verify empty state message says "No words of this length" when filter matches nothing

https://claude.ai/code/session_019QDV6YG8km8bbZH8pYLSCL