### PR TITLE
Add time extension support with per-segment score tracking

### DIFF
--- a/components/play/minimal/ActionPanel.tsx
+++ b/components/play/minimal/ActionPanel.tsx
@@ -6,17 +6,22 @@ import { WordLengthDistribution } from "./WordLengthDistribution";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import type { WordLengthCounts } from "@/lib/board/solver";
+import {
+  formatSegmentTime,
+  type Segment,
+  type SegmentWord,
+} from "@/lib/segments";
 
 interface ActionPanelProps {
   input: string;
   onInputChange: (value: string) => void;
   onSubmit: (e: React.FormEvent) => void;
-  scoreWithinTime: number;
-  scoreAfterTime: number;
+  totalScore: number;
   timeRemaining: number;
+  timeLimit: number;
+  segments: Segment<SegmentWord>[];
+  currentSegmentIndex: number;
   gameStarted: boolean;
-  wordsWithinTime: { word: string; score: number }[];
-  wordsAfterTime: { word: string; score: number }[];
   wordLengthCounts: WordLengthCounts;
   foundLengthCounts: WordLengthCounts;
   inputRef?: React.RefObject<HTMLInputElement | null>;
@@ -33,12 +38,12 @@ export function ActionPanel({
   input,
   onInputChange,
   onSubmit,
-  scoreWithinTime,
-  scoreAfterTime,
+  totalScore,
   timeRemaining,
+  timeLimit,
+  segments,
+  currentSegmentIndex,
   gameStarted,
-  wordsWithinTime,
-  wordsAfterTime,
   wordLengthCounts,
   foundLengthCounts,
   inputRef,
@@ -51,6 +56,9 @@ export function ActionPanel({
   onRevealWords
 }: ActionPanelProps) {
   const inputDisabled = isPaused || !gameStarted || !!revealedWords;
+
+  const segmentBreakdown = segments.filter(s => s.words.length > 0);
+  const showSegmentLine = segments.length > 1;
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6 md:gap-8 md:p-0">
@@ -78,9 +86,11 @@ export function ActionPanel({
 
       <div className="flex items-center justify-between border-y border-white/10 py-4">
         <div className="flex-1 text-left text-sm text-slate-100">
-          <span className="font-semibold text-emerald-300">Score:</span> {scoreWithinTime} pts
-          {scoreAfterTime > 0 && (
-             <span className="ml-1 text-slate-500">(+{scoreAfterTime})</span>
+          <span className="font-semibold text-emerald-300">Score:</span> {totalScore} pts
+          {showSegmentLine && (
+            <span className="ml-1 text-slate-500">
+              / {formatSegmentTime(timeLimit)}
+            </span>
           )}
         </div>
         <div className="flex flex-1 justify-center items-center gap-2 text-sm text-slate-100">
@@ -133,11 +143,23 @@ export function ActionPanel({
         </div>
       </div>
 
+      {showSegmentLine && segmentBreakdown.length > 0 && (
+        <div className="-mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-400">
+          {segmentBreakdown.map(s => (
+            <span
+              key={s.index}
+              className={s.index === currentSegmentIndex ? "text-emerald-300" : ""}
+            >
+              {formatSegmentTime(s.endSec)} · {s.score} pts
+            </span>
+          ))}
+        </div>
+      )}
+
       <WordLengthDistribution totalCounts={wordLengthCounts} foundCounts={foundLengthCounts} />
 
       <FoundWords
-        wordsWithinTime={wordsWithinTime}
-        wordsAfterTime={wordsAfterTime}
+        segments={segments}
         revealedWords={revealedWords}
         onRevealWords={onRevealWords}
       />

--- a/components/play/minimal/FoundWords.tsx
+++ b/components/play/minimal/FoundWords.tsx
@@ -3,24 +3,32 @@
 import { useMemo, useRef } from "react";
 import { WordList } from "./WordList";
 import { scoreWordLength } from "@/lib/scoring";
+import {
+  formatSegmentTime,
+  type Segment,
+  type SegmentWord,
+} from "@/lib/segments";
 
 interface FoundWordsProps {
-  wordsWithinTime: { word: string; score: number }[];
-  wordsAfterTime: { word: string; score: number }[];
+  segments: Segment<SegmentWord>[];
   revealedWords?: string[] | null;
   onRevealWords?: () => void;
 }
 
-export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onRevealWords }: FoundWordsProps) {
+export function FoundWords({ segments, revealedWords, onRevealWords }: FoundWordsProps) {
   const listRef = useRef<HTMLDivElement>(null);
+
+  const allFoundWords = useMemo(
+    () => segments.flatMap(s => s.words),
+    [segments]
+  );
 
   // Build the combined word list when revealed
   const allWordsDisplay = useMemo(() => {
     if (!revealedWords) return null;
 
     const foundSet = new Set<string>();
-    wordsWithinTime.forEach(w => foundSet.add(w.word.toUpperCase()));
-    wordsAfterTime.forEach(w => foundSet.add(w.word.toUpperCase()));
+    allFoundWords.forEach(w => foundSet.add(w.word.toUpperCase()));
 
     return revealedWords
       .map(word => ({
@@ -29,7 +37,10 @@ export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onR
         found: foundSet.has(word.toUpperCase()),
       }))
       .sort((a, b) => a.word.localeCompare(b.word));
-  }, [revealedWords, wordsWithinTime, wordsAfterTime]);
+  }, [revealedWords, allFoundWords]);
+
+  const nonEmptySegments = segments.filter(s => s.words.length > 0);
+  const showSegmentHeaders = segments.length > 1;
 
   return (
     <div className="flex flex-col gap-4">
@@ -60,27 +71,23 @@ export function FoundWords({ wordsWithinTime, wordsAfterTime, revealedWords, onR
                 {allWordsDisplay.filter(w => w.found).length} / {allWordsDisplay.length} words found
               </div>
             </>
-          ) : wordsWithinTime.length === 0 && wordsAfterTime.length === 0 ? (
+          ) : allFoundWords.length === 0 ? (
             <p className="text-sm italic text-slate-500">No words found yet</p>
+          ) : showSegmentHeaders ? (
+            nonEmptySegments.map((seg, idx) => (
+              <div key={`seg-${seg.index}`}>
+                {idx > 0 && <div className="my-2 border-b border-white/10" />}
+                <div className="mb-1 flex justify-between text-xs font-semibold uppercase tracking-wider text-slate-500">
+                  <span>
+                    {formatSegmentTime(seg.startSec)}–{formatSegmentTime(seg.endSec)}
+                  </span>
+                  <span>{seg.score} pts</span>
+                </div>
+                <WordList words={seg.words} emptyMessage="" />
+              </div>
+            ))
           ) : (
-            <>
-              <WordList words={wordsWithinTime} emptyMessage="" />
-
-              {wordsAfterTime.length > 0 && (
-                <>
-                  <div className="my-2 border-b border-white/10" />
-                  <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
-                    Overtime
-                  </div>
-                  {wordsAfterTime.map((w, i) => (
-                    <div key={`after-${i}`} className="flex justify-between py-1 text-sm text-slate-500">
-                      <span>{w.word}</span>
-                      <span>({w.score} pts)</span>
-                    </div>
-                  ))}
-                </>
-              )}
-            </>
+            <WordList words={allFoundWords} emptyMessage="" />
           )}
         </div>
 

--- a/components/play/minimal/TimeUpModal.tsx
+++ b/components/play/minimal/TimeUpModal.tsx
@@ -2,32 +2,84 @@
 
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import {
+  formatSegmentTime,
+  segmentBreakdownLines,
+  type Segment,
+  type SegmentWord,
+} from "@/lib/segments";
 
 interface TimeUpModalProps {
-  score: number;
+  totalScore: number;
   wordsFound: number;
+  timeLimit: number;
+  segments: Segment<SegmentWord>[];
   onShare: () => void;
-  onKeepPlaying: () => void;
+  onExtend: () => void;
+  onDismiss: () => void;
   isOpen: boolean;
 }
 
-export function TimeUpModal({ score, wordsFound, onShare, onKeepPlaying, isOpen }: TimeUpModalProps) {
+export function TimeUpModal({
+  totalScore,
+  wordsFound,
+  timeLimit,
+  segments,
+  onShare,
+  onExtend,
+  onDismiss,
+  isOpen,
+}: TimeUpModalProps) {
   if (!isOpen) return null;
+
+  const breakdown = segmentBreakdownLines(segments);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div className="w-full max-w-sm rounded-lg border border-white/10 bg-slate-900 p-6 shadow-xl shadow-black/50">
-        <h2 className="mb-2 text-center text-2xl font-bold text-white">Time's Up!</h2>
-        <p className="mb-6 text-center text-slate-300">
-          You found <span className="font-semibold text-white">{wordsFound}</span> words for <span className="font-semibold text-emerald-300">{score}</span> points!
+        <h2 className="mb-2 text-center text-2xl font-bold text-white">Time&apos;s Up!</h2>
+        <p className="mb-4 text-center text-slate-300">
+          You found <span className="font-semibold text-white">{wordsFound}</span> words for{" "}
+          <span className="font-semibold text-emerald-300">{totalScore}</span> points in{" "}
+          <span className="font-semibold text-white">{formatSegmentTime(timeLimit)}</span>!
         </p>
 
+        {breakdown.length > 1 && (
+          <div className="mb-5 rounded border border-white/10 bg-slate-950/50 px-3 py-2 text-sm text-slate-300">
+            {breakdown.map(line => (
+              <div key={line.label} className="flex justify-between py-0.5">
+                <span className="text-slate-400">{line.label}</span>
+                <span>
+                  <span className="font-semibold text-emerald-300">{line.score}</span>
+                  <span className="text-slate-500"> · {line.wordCount}w</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
         <div className="flex flex-col gap-3">
-          <Button type="button" onClick={onShare} className="w-full bg-emerald-500 text-white hover:bg-emerald-600">
+          <Button
+            type="button"
+            onClick={onExtend}
+            className="w-full bg-emerald-500 text-white hover:bg-emerald-600"
+          >
+            +5 more minutes
+          </Button>
+          <Button
+            type="button"
+            onClick={onShare}
+            className="w-full bg-slate-800 text-white hover:bg-slate-700"
+          >
             Share Score
           </Button>
-          <Button type="button" onClick={onKeepPlaying} className="w-full bg-slate-800 text-white hover:bg-slate-700">
-            Keep Playing
+          <Button
+            type="button"
+            onClick={onDismiss}
+            variant="ghost"
+            className="w-full text-slate-400 hover:text-white hover:bg-white/10"
+          >
+            Close
           </Button>
           <Link
             href="/share"

--- a/components/play/word-grid.tsx
+++ b/components/play/word-grid.tsx
@@ -12,6 +12,13 @@ import {
 import { scoreWordLength } from "@/lib/scoring";
 import { MIN_PATH_LENGTH } from "@/lib/validation/paths";
 import type { WordLengthCounts } from "@/lib/board/solver";
+import {
+  SEGMENT_SECONDS,
+  DEFAULT_TIME_LIMIT_SECONDS,
+  buildSegments,
+  formatSegmentTime,
+  segmentBreakdownLines,
+} from "@/lib/segments";
 
 import { BoardComponent, InteractionType, FeedbackState, FeedbackType } from "./minimal/Board";
 import { ActionPanel } from "./minimal/ActionPanel";
@@ -25,8 +32,6 @@ export type WordGridProps = {
 };
 
 type AddedWord = { word: string; score: number; timestamp?: string; elapsedAt?: number };
-
-const TIME_LIMIT_SECONDS = 300; // 5 minutes
 
 export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) {
   const [words, setWords] = useState<AddedWord[]>([]);
@@ -42,11 +47,13 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
   // Pause & timer state
   const [gameStarted, setGameStarted] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
-  const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT_SECONDS);
+  const [timeLimit, setTimeLimit] = useState(DEFAULT_TIME_LIMIT_SECONDS);
+  const [timeRemaining, setTimeRemaining] = useState(DEFAULT_TIME_LIMIT_SECONDS);
 
   // Refs for timer logic (avoid stale closures in interval)
   const elapsedBaseRef = useRef(0);       // accumulated elapsed seconds from DB / previous play sessions
   const playResumedAtRef = useRef<number | null>(null); // Date.now() when current play session started
+  const timeLimitRef = useRef(DEFAULT_TIME_LIMIT_SECONDS);
   const userIdRef = useRef<string | null>(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -71,7 +78,7 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
   const getCurrentElapsed = useCallback(() => {
     if (playResumedAtRef.current !== null) {
       const deltaS = (Date.now() - playResumedAtRef.current) / 1000;
-      return Math.min(TIME_LIMIT_SECONDS, elapsedBaseRef.current + deltaS);
+      return Math.min(timeLimitRef.current, elapsedBaseRef.current + deltaS);
     }
     return elapsedBaseRef.current;
   }, []);
@@ -121,7 +128,7 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
           .from("daily_boards")
           .select("board_date")
           .eq("user_id", data.user.id)
-          .gte("elapsed_seconds", TIME_LIMIT_SECONDS)
+          .gte("elapsed_seconds", DEFAULT_TIME_LIMIT_SECONDS)
           .order("board_date", { ascending: false })
           .then(({ data: completedDays }) => {
             if (!completedDays?.length) return;
@@ -153,25 +160,28 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
             setStreak(count);
           });
 
-        // Fetch board state (elapsed_seconds)
+        // Fetch board state (elapsed_seconds + time_limit_seconds)
         supabase
           .from("daily_boards")
-          .select("board_started, elapsed_seconds")
+          .select("board_started, elapsed_seconds, time_limit_seconds")
           .eq("user_id", data.user.id)
           .eq("board_date", boardDate)
           .single()
           .then(({ data: boardData }) => {
             if (boardData?.board_started) {
               const elapsed = boardData.elapsed_seconds ?? 0;
+              const limit = boardData.time_limit_seconds ?? DEFAULT_TIME_LIMIT_SECONDS;
               elapsedBaseRef.current = elapsed;
+              timeLimitRef.current = limit;
+              setTimeLimit(limit);
               setGameStarted(true);
 
-              if (elapsed >= TIME_LIMIT_SECONDS) {
+              if (elapsed >= limit) {
                 setTimeRemaining(0);
-                setIsPaused(false);
+                setIsPaused(true);
               } else {
                 // Always load as paused — user clicks Resume to continue
-                setTimeRemaining(TIME_LIMIT_SECONDS - elapsed);
+                setTimeRemaining(limit - elapsed);
                 setIsPaused(true);
               }
             }
@@ -241,38 +251,38 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
     playResumedAtRef.current = Date.now();
 
     // Immediate display update
-    setTimeRemaining(Math.max(0, TIME_LIMIT_SECONDS - Math.floor(elapsedBaseRef.current)));
+    setTimeRemaining(
+      Math.max(0, timeLimitRef.current - Math.floor(elapsedBaseRef.current))
+    );
 
     const interval = setInterval(() => {
+      const limit = timeLimitRef.current;
       const deltaS = (Date.now() - playResumedAtRef.current!) / 1000;
       const currentElapsed = elapsedBaseRef.current + deltaS;
-      const remaining = Math.max(0, TIME_LIMIT_SECONDS - Math.floor(currentElapsed));
+      const remaining = Math.max(0, limit - Math.floor(currentElapsed));
 
       setTimeRemaining(remaining);
-      syncElapsedToDb(Math.floor(currentElapsed));
+      syncElapsedToDb(Math.floor(Math.min(limit, currentElapsed)));
 
       if (remaining <= 0) {
-        elapsedBaseRef.current = TIME_LIMIT_SECONDS;
-        syncElapsedToDb(TIME_LIMIT_SECONDS);
-        if (typeof window !== 'undefined') {
-          const key = `wordgrid-time-up-seen-${boardDate}`;
-          if (!localStorage.getItem(key)) {
-            setShowTimeUpModal(true);
-          }
-        }
+        elapsedBaseRef.current = limit;
+        playResumedAtRef.current = null;
+        syncElapsedToDb(limit);
+        setIsPaused(true);
+        setShowTimeUpModal(true);
         clearInterval(interval);
       }
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [gameStarted, isPaused, boardDate, syncElapsedToDb]);
+  }, [gameStarted, isPaused, syncElapsedToDb]);
 
   // Sync elapsed time when page is being hidden (tab switch, close, refresh)
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden' && playResumedAtRef.current !== null) {
         const deltaS = (Date.now() - playResumedAtRef.current) / 1000;
-        const currentElapsed = Math.min(TIME_LIMIT_SECONDS, elapsedBaseRef.current + deltaS);
+        const currentElapsed = Math.min(timeLimitRef.current, elapsedBaseRef.current + deltaS);
         syncElapsedToDb(Math.floor(currentElapsed));
       }
     };
@@ -280,39 +290,33 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [syncElapsedToDb]);
 
-  // Categorize words using elapsed_at (play-time based, not wall-clock)
-  const { wordsWithinTime, wordsAfterTime, scoreWithinTime, scoreAfterTime, foundLengthCounts } = useMemo(() => {
-    const within: AddedWord[] = [];
-    const after: AddedWord[] = [];
-    let sWithin = 0;
-    let sAfter = 0;
+  // Bucket words into 5-minute segments based on elapsed_at.
+  const segments = useMemo(
+    () => buildSegments(words, timeLimit),
+    [words, timeLimit]
+  );
+
+  const { totalScore, foundLengthCounts } = useMemo(() => {
     const foundCounts: WordLengthCounts = { "4": 0, "5": 0, "6": 0, "7": 0, "8+": 0 };
-
+    let total = 0;
     words.forEach(w => {
-      const isOvertime = w.elapsedAt != null && w.elapsedAt >= TIME_LIMIT_SECONDS;
-
-      if (isOvertime) {
-        after.push(w);
-        sAfter += w.score;
-      } else {
-        within.push(w);
-        sWithin += w.score;
-      }
-
-      // Count by length bucket (all words, including overtime)
+      total += w.score;
       const len = w.word.length;
       if (len >= 8) foundCounts["8+"]++;
       else if (len >= 4) foundCounts[String(len)]++;
     });
-
-    return {
-      wordsWithinTime: within.sort((a, b) => a.word.localeCompare(b.word)),
-      wordsAfterTime: after.sort((a, b) => a.word.localeCompare(b.word)),
-      scoreWithinTime: sWithin,
-      scoreAfterTime: sAfter,
-      foundLengthCounts: foundCounts,
-    };
+    return { totalScore: total, foundLengthCounts: foundCounts };
   }, [words]);
+
+  // Segments with alphabetically-sorted word lists for display.
+  const displaySegments = useMemo(
+    () =>
+      segments.map(s => ({
+        ...s,
+        words: [...s.words].sort((a, b) => a.word.localeCompare(b.word)),
+      })),
+    [segments]
+  );
 
   // Calculate highlighted cells based on input or drag
   const highlightedCells = useMemo(() => {
@@ -333,12 +337,20 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
     const now = new Date().toISOString();
     if (userIdRef.current) {
       await supabase.from("daily_boards").upsert(
-        { user_id: userIdRef.current, board_date: boardDate, board_started: now, elapsed_seconds: 0 },
+        {
+          user_id: userIdRef.current,
+          board_date: boardDate,
+          board_started: now,
+          elapsed_seconds: 0,
+          time_limit_seconds: DEFAULT_TIME_LIMIT_SECONDS,
+        },
         { onConflict: "user_id, board_date", ignoreDuplicates: true }
       );
     }
     elapsedBaseRef.current = 0;
-    setTimeRemaining(TIME_LIMIT_SECONDS);
+    timeLimitRef.current = DEFAULT_TIME_LIMIT_SECONDS;
+    setTimeLimit(DEFAULT_TIME_LIMIT_SECONDS);
+    setTimeRemaining(DEFAULT_TIME_LIMIT_SECONDS);
     setGameStarted(true);
     setIsPaused(false);
   }, [boardDate]);
@@ -353,7 +365,10 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
       // Pause: snapshot elapsed time and sync to DB
       if (playResumedAtRef.current !== null) {
         const deltaS = (Date.now() - playResumedAtRef.current) / 1000;
-        elapsedBaseRef.current = Math.min(TIME_LIMIT_SECONDS, elapsedBaseRef.current + deltaS);
+        elapsedBaseRef.current = Math.min(
+          timeLimitRef.current,
+          elapsedBaseRef.current + deltaS
+        );
         syncElapsedToDb(Math.floor(elapsedBaseRef.current));
         playResumedAtRef.current = null;
       }
@@ -361,18 +376,39 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
     }
   }, [isPaused, syncElapsedToDb]);
 
+  // Extend the session by one more 5-minute segment.
+  const handleExtendTime = useCallback(async () => {
+    const newLimit = timeLimitRef.current + SEGMENT_SECONDS;
+    timeLimitRef.current = newLimit;
+    setTimeLimit(newLimit);
+    setTimeRemaining(Math.max(0, newLimit - Math.floor(elapsedBaseRef.current)));
+    setShowTimeUpModal(false);
+
+    if (userIdRef.current) {
+      const { error } = await supabase
+        .from("daily_boards")
+        .update({ time_limit_seconds: newLimit })
+        .eq("user_id", userIdRef.current)
+        .eq("board_date", boardDate);
+      if (error) {
+        console.error("Failed to persist time extension:", error);
+      }
+    }
+
+    setIsPaused(false);
+    focusInput();
+  }, [boardDate, focusInput]);
+
   async function handleShare() {
-    // Generate breakdown by length
+    // Length breakdown across all found words
     const lengthCounts = new Map<number, number>();
-    wordsWithinTime.forEach(w => {
+    words.forEach(w => {
       const len = w.word.length;
       lengthCounts.set(len, (lengthCounts.get(len) || 0) + 1);
     });
-
-    // Sort lengths
     const sortedLengths = Array.from(lengthCounts.keys()).sort((a, b) => a - b);
 
-    let breakdown = "";
+    let lengthBreakdown = "";
     sortedLengths.forEach(len => {
         const count = lengthCounts.get(len);
         let emoji = "";
@@ -383,18 +419,26 @@ export function WordGrid({ board, boardDate, wordLengthCounts }: WordGridProps) 
         else if (len === 8) emoji = "8️⃣";
         else if (len === 9) emoji = "9️⃣";
         else if (len === 10) emoji = "🔟";
-        else emoji = `${len}`; // Fallback
+        else emoji = `${len}`;
 
         if (emoji) {
-            breakdown += `${emoji}: ${count} ${count === 1 ? 'word' : 'words'}\n`;
+            lengthBreakdown += `${emoji}: ${count} ${count === 1 ? 'word' : 'words'}\n`;
         }
     });
 
-    const text = `I got ${scoreWithinTime} points on Daily Word Grid today!
-${breakdown}`;
+    const timePlayed = formatSegmentTime(timeLimit);
+    const segmentLines = segmentBreakdownLines(segments);
+    const segmentText = segmentLines
+      .map(l => `• ${l.label} — ${l.score} pts (${l.wordCount} ${l.wordCount === 1 ? "word" : "words"})`)
+      .join("\n");
+
+    const header = `Daily Word Grid — ${totalScore} pts in ${timePlayed}`;
+    const body = segmentLines.length > 1
+      ? `${header}\n${segmentText}\n${lengthBreakdown}`
+      : `${header}\n${lengthBreakdown}`;
 
     const url = window.location.href;
-    const fullText = `${text}${url}`;
+    const fullText = `${body}${url}`;
 
     const shareData = {
       title: 'Daily Wordgrid',
@@ -413,14 +457,6 @@ ${breakdown}`;
     // Fallback to clipboard
     navigator.clipboard.writeText(fullText);
     toast.success("Score copied to clipboard!");
-  }
-
-  function handleKeepPlaying() {
-    setShowTimeUpModal(false);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(`wordgrid-time-up-seen-${boardDate}`, 'true');
-    }
-    focusInput();
   }
 
   async function handleSubmit(e?: React.FormEvent, explicitWord?: string, explicitPath?: {row: number, col: number}[]) {
@@ -653,19 +689,29 @@ ${breakdown}`;
     );
   };
 
+  // Progress bar fills the current 5-minute segment so each extension feels fresh.
+  const elapsedSeconds = timeLimit - timeRemaining;
+  const segmentProgressFraction = timeRemaining <= 0
+    ? 0
+    : Math.max(0, Math.min(1, (SEGMENT_SECONDS - (elapsedSeconds % SEGMENT_SECONDS)) / SEGMENT_SECONDS));
+  const currentSegmentIndex = Math.min(
+    segments.length - 1,
+    Math.floor(elapsedSeconds / SEGMENT_SECONDS)
+  );
+
   return (
     <div className="grid gap-4 sm:gap-6 lg:gap-8 lg:grid-cols-[1fr_400px]">
       {/* Board Column */}
       <div className="flex justify-center lg:justify-start">
         <div className="w-full sm:max-w-[360px] md:max-w-[420px] lg:max-w-[500px]">
           {renderBoardArea()}
-          {/* Time remaining bar */}
+          {/* Time remaining bar — per segment */}
           {gameStarted && (
             <div className="mt-2 h-1 w-full rounded-full bg-white/10 overflow-hidden">
               <div
                 className="h-full bg-emerald-500 rounded-full transition-all duration-1000 ease-linear"
                 style={{
-                  width: `${(timeRemaining / TIME_LIMIT_SECONDS) * 100}%`,
+                  width: `${segmentProgressFraction * 100}%`,
                   transformOrigin: 'right',
                 }}
               />
@@ -681,12 +727,12 @@ ${breakdown}`;
           input={input}
           onInputChange={setInput}
           onSubmit={handleSubmit}
-          scoreWithinTime={scoreWithinTime}
-          scoreAfterTime={scoreAfterTime}
+          totalScore={totalScore}
           timeRemaining={timeRemaining}
+          timeLimit={timeLimit}
+          segments={displaySegments}
+          currentSegmentIndex={currentSegmentIndex}
           gameStarted={gameStarted}
-          wordsWithinTime={wordsWithinTime}
-          wordsAfterTime={wordsAfterTime}
           wordLengthCounts={wordLengthCounts}
           foundLengthCounts={foundLengthCounts}
           onShare={handleShare}
@@ -700,10 +746,13 @@ ${breakdown}`;
       </div>
 
       <TimeUpModal
-        score={scoreWithinTime}
-        wordsFound={wordsWithinTime.length}
+        totalScore={totalScore}
+        wordsFound={words.length}
+        timeLimit={timeLimit}
+        segments={segments}
         onShare={handleShare}
-        onKeepPlaying={handleKeepPlaying}
+        onExtend={handleExtendTime}
+        onDismiss={() => setShowTimeUpModal(false)}
         isOpen={showTimeUpModal}
       />
 

--- a/db/migrations/009_add_time_extensions.sql
+++ b/db/migrations/009_add_time_extensions.sql
@@ -1,0 +1,5 @@
+-- Adds support for time extensions on daily boards.
+-- Players can extend past the default 5 minutes in 5-minute increments.
+-- Score segmentation is derived at render time from each word's elapsed_at.
+ALTER TABLE daily_boards
+  ADD COLUMN IF NOT EXISTS time_limit_seconds INTEGER NOT NULL DEFAULT 300;

--- a/lib/segments.ts
+++ b/lib/segments.ts
@@ -1,0 +1,76 @@
+export const SEGMENT_SECONDS = 300;
+export const DEFAULT_TIME_LIMIT_SECONDS = SEGMENT_SECONDS;
+
+export type SegmentWord = {
+  word: string;
+  score: number;
+  elapsedAt?: number;
+};
+
+export type Segment<W extends SegmentWord = SegmentWord> = {
+  index: number;
+  startSec: number;
+  endSec: number;
+  words: W[];
+  score: number;
+};
+
+/**
+ * Bucket words into fixed 5-minute segments based on elapsed_at.
+ * Always returns at least ceil(timeLimitSeconds / SEGMENT_SECONDS) segments
+ * so the UI shows empty trailing buckets for time the user has committed to.
+ * Words with elapsed_at past the last segment (shouldn't happen in practice,
+ * but guards older data) land in the final bucket.
+ */
+export function buildSegments<W extends SegmentWord>(
+  words: W[],
+  timeLimitSeconds: number
+): Segment<W>[] {
+  const segmentCount = Math.max(
+    1,
+    Math.ceil(timeLimitSeconds / SEGMENT_SECONDS)
+  );
+
+  const segments: Segment<W>[] = Array.from({ length: segmentCount }, (_, i) => ({
+    index: i,
+    startSec: i * SEGMENT_SECONDS,
+    endSec: (i + 1) * SEGMENT_SECONDS,
+    words: [],
+    score: 0,
+  }));
+
+  for (const w of words) {
+    const elapsed = w.elapsedAt ?? 0;
+    let idx = Math.floor(elapsed / SEGMENT_SECONDS);
+    if (idx < 0) idx = 0;
+    if (idx >= segmentCount) idx = segmentCount - 1;
+    segments[idx].words.push(w);
+    segments[idx].score += w.score;
+  }
+
+  return segments;
+}
+
+/** Format a second offset as M:SS (e.g. 300 → "5:00"). */
+export function formatSegmentTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export type SegmentBreakdownLine = {
+  label: string;
+  score: number;
+  wordCount: number;
+};
+
+/** Produce printable "5:00 — 80 pts (3 words)" lines, skipping empty segments. */
+export function segmentBreakdownLines(segments: Segment[]): SegmentBreakdownLine[] {
+  return segments
+    .filter(s => s.words.length > 0)
+    .map(s => ({
+      label: `${formatSegmentTime(s.startSec)}–${formatSegmentTime(s.endSec)}`,
+      score: s.score,
+      wordCount: s.words.length,
+    }));
+}

--- a/tests/components/play/minimal/TimeUpModal.test.tsx
+++ b/tests/components/play/minimal/TimeUpModal.test.tsx
@@ -1,67 +1,76 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { TimeUpModal } from "@/components/play/minimal/TimeUpModal";
+import { buildSegments } from "@/lib/segments";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 afterEach(cleanup);
 
+const baseProps = {
+  totalScore: 100,
+  wordsFound: 5,
+  timeLimit: 300,
+  segments: buildSegments([], 300),
+  onShare: () => {},
+  onExtend: () => {},
+  onDismiss: () => {},
+};
+
 describe("TimeUpModal", () => {
   it("does not render when not open", () => {
-    render(
-      <TimeUpModal
-        score={10}
-        wordsFound={5}
-        onShare={() => {}}
-        onKeepPlaying={() => {}}
-        isOpen={false}
-      />
-    );
+    render(<TimeUpModal {...baseProps} isOpen={false} />);
     expect(screen.queryByText("Time's Up!")).toBeNull();
   });
 
-  it("renders correctly when open", () => {
-    render(
-      <TimeUpModal
-        score={100}
-        wordsFound={5}
-        onShare={() => {}}
-        onKeepPlaying={() => {}}
-        isOpen={true}
-      />
-    );
+  it("renders score, words, and time-played when open", () => {
+    render(<TimeUpModal {...baseProps} isOpen={true} />);
     expect(screen.getByText("Time's Up!")).toBeInTheDocument();
-    expect(screen.getByText("100")).toBeInTheDocument(); // Score
-    expect(screen.getByText("5")).toBeInTheDocument(); // Words
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("5:00")).toBeInTheDocument();
+    expect(screen.getByText("+5 more minutes")).toBeInTheDocument();
     expect(screen.getByText("Share Score")).toBeInTheDocument();
-    expect(screen.getByText("Keep Playing")).toBeInTheDocument();
   });
 
-  it("calls onShare when Share button is clicked", () => {
-    const handleShare = vi.fn();
-    render(
-      <TimeUpModal
-        score={10}
-        wordsFound={5}
-        onShare={handleShare}
-        onKeepPlaying={() => {}}
-        isOpen={true}
-      />
-    );
+  it("calls onExtend when +5 more minutes is clicked", () => {
+    const onExtend = vi.fn();
+    render(<TimeUpModal {...baseProps} onExtend={onExtend} isOpen={true} />);
+    fireEvent.click(screen.getByText("+5 more minutes"));
+    expect(onExtend).toHaveBeenCalled();
+  });
+
+  it("calls onShare when Share Score is clicked", () => {
+    const onShare = vi.fn();
+    render(<TimeUpModal {...baseProps} onShare={onShare} isOpen={true} />);
     fireEvent.click(screen.getByText("Share Score"));
-    expect(handleShare).toHaveBeenCalled();
+    expect(onShare).toHaveBeenCalled();
   });
 
-  it("calls onKeepPlaying when Keep Playing button is clicked", () => {
-    const handleKeepPlaying = vi.fn();
+  it("calls onDismiss when Close is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<TimeUpModal {...baseProps} onDismiss={onDismiss} isOpen={true} />);
+    fireEvent.click(screen.getByText("Close"));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("shows per-segment breakdown once multiple segments exist", () => {
+    const segments = buildSegments(
+      [
+        { word: "ALPHA", score: 2, elapsedAt: 10 },
+        { word: "BETA", score: 1, elapsedAt: 310 },
+      ],
+      600
+    );
     render(
       <TimeUpModal
-        score={10}
-        wordsFound={5}
-        onShare={() => {}}
-        onKeepPlaying={handleKeepPlaying}
+        {...baseProps}
+        timeLimit={600}
+        segments={segments}
+        totalScore={3}
+        wordsFound={2}
         isOpen={true}
       />
     );
-    fireEvent.click(screen.getByText("Keep Playing"));
-    expect(handleKeepPlaying).toHaveBeenCalled();
+    expect(screen.getByText("0:00–5:00")).toBeInTheDocument();
+    expect(screen.getByText("5:00–10:00")).toBeInTheDocument();
   });
 });

--- a/tests/segments.test.ts
+++ b/tests/segments.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSegments,
+  segmentBreakdownLines,
+  formatSegmentTime,
+  SEGMENT_SECONDS,
+} from "@/lib/segments";
+
+describe("buildSegments", () => {
+  it("returns a single segment at the default time limit", () => {
+    const segs = buildSegments([], SEGMENT_SECONDS);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toMatchObject({ index: 0, startSec: 0, endSec: 300, score: 0 });
+    expect(segs[0].words).toEqual([]);
+  });
+
+  it("creates one segment per 5-minute block up to the time limit", () => {
+    const segs = buildSegments([], 900);
+    expect(segs.map(s => [s.startSec, s.endSec])).toEqual([
+      [0, 300],
+      [300, 600],
+      [600, 900],
+    ]);
+  });
+
+  it("buckets words by elapsed_at", () => {
+    const words = [
+      { word: "EARLY", score: 2, elapsedAt: 10 },
+      { word: "MIDDLE", score: 3, elapsedAt: 250 },
+      { word: "SECOND", score: 3, elapsedAt: 301 },
+      { word: "LATE", score: 1, elapsedAt: 599 },
+      { word: "THIRDD", score: 3, elapsedAt: 700 },
+    ];
+    const segs = buildSegments(words, 900);
+
+    expect(segs[0].words.map(w => w.word)).toEqual(["EARLY", "MIDDLE"]);
+    expect(segs[0].score).toBe(5);
+
+    expect(segs[1].words.map(w => w.word)).toEqual(["SECOND", "LATE"]);
+    expect(segs[1].score).toBe(4);
+
+    expect(segs[2].words.map(w => w.word)).toEqual(["THIRDD"]);
+    expect(segs[2].score).toBe(3);
+  });
+
+  it("treats missing elapsedAt as 0 (first segment)", () => {
+    const segs = buildSegments(
+      [{ word: "OLD", score: 2 }],
+      600
+    );
+    expect(segs[0].words).toHaveLength(1);
+    expect(segs[1].words).toHaveLength(0);
+  });
+
+  it("clamps out-of-range elapsed_at into the last segment", () => {
+    const segs = buildSegments(
+      [{ word: "LATEWORD", score: 11, elapsedAt: 9999 }],
+      600
+    );
+    expect(segs[segs.length - 1].words).toHaveLength(1);
+  });
+
+  it("segment boundaries are half-open: exactly 300s goes to segment 1", () => {
+    const segs = buildSegments(
+      [
+        { word: "ONBOUND", score: 5, elapsedAt: 300 },
+        { word: "BEFORE", score: 3, elapsedAt: 299 },
+      ],
+      600
+    );
+    expect(segs[0].words.map(w => w.word)).toEqual(["BEFORE"]);
+    expect(segs[1].words.map(w => w.word)).toEqual(["ONBOUND"]);
+  });
+});
+
+describe("segmentBreakdownLines", () => {
+  it("skips empty segments", () => {
+    const segs = buildSegments(
+      [{ word: "HI", score: 1, elapsedAt: 0 }],
+      900
+    );
+    const lines = segmentBreakdownLines(segs);
+    expect(lines).toEqual([
+      { label: "0:00–5:00", score: 1, wordCount: 1 },
+    ]);
+  });
+
+  it("produces labels for each non-empty segment", () => {
+    const segs = buildSegments(
+      [
+        { word: "A", score: 2, elapsedAt: 10 },
+        { word: "B", score: 3, elapsedAt: 400 },
+        { word: "C", score: 3, elapsedAt: 410 },
+      ],
+      900
+    );
+    const lines = segmentBreakdownLines(segs);
+    expect(lines).toEqual([
+      { label: "0:00–5:00", score: 2, wordCount: 1 },
+      { label: "5:00–10:00", score: 6, wordCount: 2 },
+    ]);
+  });
+});
+
+describe("formatSegmentTime", () => {
+  it("formats minute/second values", () => {
+    expect(formatSegmentTime(0)).toBe("0:00");
+    expect(formatSegmentTime(5)).toBe("0:05");
+    expect(formatSegmentTime(65)).toBe("1:05");
+    expect(formatSegmentTime(300)).toBe("5:00");
+    expect(formatSegmentTime(900)).toBe("15:00");
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds support for extending game time in 5-minute increments and refactors score tracking to be segment-based rather than binary (within/after time). Players can now extend their session when time runs out, and the UI displays a breakdown of points earned in each 5-minute segment.

## Changes

- **Time Extension System**: Added `time_limit_seconds` column to `daily_boards` table. Players can extend the game by 5 minutes via the "Time's Up" modal, which persists the new limit to the database.

- **Segment-Based Architecture**: Introduced `lib/segments.ts` with core utilities:
  - `buildSegments()`: Buckets words into fixed 5-minute segments based on `elapsedAt`
  - `formatSegmentTime()`: Formats seconds as M:SS
  - `segmentBreakdownLines()`: Generates printable segment summaries
  - Constants: `SEGMENT_SECONDS` (300) and `DEFAULT_TIME_LIMIT_SECONDS`

- **UI Updates**:
  - `TimeUpModal`: Now shows time played, per-segment breakdown (when multiple segments exist), and "+5 more minutes" button instead of "Keep Playing"
  - `ActionPanel`: Displays segment breakdown inline when time has been extended
  - `FoundWords`: Groups words by segment with headers showing time range and segment score
  - Progress bar now fills per-segment (resets on each extension) for visual feedback

- **Game Logic**:
  - Replaced `TIME_LIMIT_SECONDS` constant with dynamic `timeLimit` state and `timeLimitRef`
  - Timer respects the current time limit; when time expires, game pauses and modal shows
  - Removed localStorage-based "time up seen" tracking; modal always shows on expiry
  - Share text now includes segment breakdown and formatted time played

- **Database**: Added migration to create `time_limit_seconds` column with default value

## Checklist

- [x] Added unit tests for segment bucketing, formatting, and breakdown generation (`tests/segments.test.ts`)
- [x] Updated `TimeUpModal` tests to cover new extend/dismiss flow and segment display
- [x] Refactored component props to use segment-based data structures
- [x] Removed overtime-specific UI in favor of unified segment display

## Notes for Reviewers

- The segment system is backward-compatible: words without `elapsedAt` default to segment 0
- Progress bar now shows per-segment progress (fills fresh on each extension) rather than overall progress
- Share text generation now includes segment breakdown when multiple segments exist, providing richer context
- All timer logic uses `timeLimitRef` to avoid stale closures in intervals

https://claude.ai/code/session_01Y312KFcdrTFZqbLExk4VMU